### PR TITLE
Fix chart selection overshooting its target when stacking scrolls

### DIFF
--- a/src/Features/LevelSelect/Tree.fs
+++ b/src/Features/LevelSelect/Tree.fs
@@ -36,7 +36,7 @@ module Tree =
     let mutable private expandedGroup = ""
     
     let private scrollPos = Animation.Fade 300.0f
-    let private scroll(amount: float32) = scrollPos.Target <- scrollPos.Target + amount
+    let private scroll(amount: float32) = scrollPos.Target <- scrollPos.Value + amount
 
     let mutable private currently_drag_scrolling = false
     let mutable private drag_scroll_distance = 0.0f


### PR DESCRIPTION
Minor fixes for days on end
Alternative title: Fix scroll over-scrolling when trying to scroll during an active scroll